### PR TITLE
Set both the internal and non-internal JAX-WS SSLSocketFactory property.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <groupId>io.curity.identityserver.plugin</groupId>
     <artifactId>identityserver.plugins.consentor.cgi-grp2-signing-consentor</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/io/curity/identityserver/plugin/cgigrp2consentor/CgiGrp2SigningClient.java
+++ b/src/main/java/io/curity/identityserver/plugin/cgigrp2consentor/CgiGrp2SigningClient.java
@@ -33,6 +33,7 @@ import se.curity.identityserver.sdk.service.trust.TrustManagerFactory;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.xml.ws.BindingProvider;
 import java.net.URI;
@@ -67,6 +68,8 @@ public class CgiGrp2SigningClient
 
     private static final String JAXWS_PROPERTIES_SSL_SOCKET_FACTORY_INTERNAL
             = "com.sun.xml.internal.ws.transport.https.client.SSLSocketFactory";
+    private static final String JAXWS_PROPERTIES_SSL_SOCKET_FACTORY
+            = "com.sun.xml.ws.transport.https.client.SSLSocketFactory";
 
     public CgiGrp2SigningClient(ExceptionFactory exceptionFactory,
                                 GRPOperationalMode operationalMode,
@@ -194,7 +197,10 @@ public class CgiGrp2SigningClient
 
         String endpoint = resolveEndpoint();
         bindingProvider.getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, endpoint);
-        bindingProvider.getRequestContext().put(JAXWS_PROPERTIES_SSL_SOCKET_FACTORY_INTERNAL, sc.getSocketFactory());
+
+        SSLSocketFactory socketFactory = sc.getSocketFactory();
+        bindingProvider.getRequestContext().put(JAXWS_PROPERTIES_SSL_SOCKET_FACTORY_INTERNAL, socketFactory);
+        bindingProvider.getRequestContext().put(JAXWS_PROPERTIES_SSL_SOCKET_FACTORY, socketFactory);
 
         return port;
     }

--- a/src/main/java/io/curity/identityserver/plugin/cgigrp2consentor/CgiGrp2SigningClient.java
+++ b/src/main/java/io/curity/identityserver/plugin/cgigrp2consentor/CgiGrp2SigningClient.java
@@ -199,6 +199,7 @@ public class CgiGrp2SigningClient
         bindingProvider.getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, endpoint);
 
         SSLSocketFactory socketFactory = sc.getSocketFactory();
+        // Set both properties so that the plugin is usable with the bundled JAX-WS implementation and the reference implementation.
         bindingProvider.getRequestContext().put(JAXWS_PROPERTIES_SSL_SOCKET_FACTORY_INTERNAL, socketFactory);
         bindingProvider.getRequestContext().put(JAXWS_PROPERTIES_SSL_SOCKET_FACTORY, socketFactory);
 


### PR DESCRIPTION
This makes the plugin usable with the JAX-WS reference implementation.